### PR TITLE
Update hassio config.json with arch and new docker

### DIFF
--- a/hassio/config.json
+++ b/hassio/config.json
@@ -4,10 +4,11 @@
     "slug": "insteon-mqtt",
     "version": "0.6.8",
     "startup": "services",
+    "arch": ["amd64","armhf","aarch64","i386"],
     "boot": "auto",
     "auto_uart": true,
     "map": ["config:rw"],
     "options": {},
     "schema": {},
-    "image": "lnr0626/{arch}-insteon-mqtt"
+    "image": "td22057/{arch}-insteon-mqtt"
 }


### PR DESCRIPTION
Fixes a couple of issues:
* config.json for the addon has changed formats and requires a list of valid "arch" files. Fixes GH-148, Fixes GH-139
* Use new repo. Fixes GH-137